### PR TITLE
Manually set version number to 1.20.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@ POSSIBILITY OF SUCH DAMAGE.
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>gov.nasa</groupId>
-  <artifactId>pds</artifactId>
-  <version>1.19.0-SNAPSHOT</version>
+  <groupId>gov.nasa.pds</groupId>
+  <artifactId>parent</artifactId>
+  <version>1.20.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Planetary Data System Parent POM</name>


### PR DESCRIPTION
## 🗒️ Summary

Parent POM is now known as `gov.nasa.pds:parent` and production version `1.19.0` has been [published to the new Central Repository Portal](https://central.sonatype.com/artifact/gov.nasa.pds/parent).

We need to manually set the next version number to `1.20.0-SNAPSHOT` via this PR.

## ⚙️ Test Data and/or Report

N/A

## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128?issue=NASA-PDS%7Csoftware-issues-repo%7C129